### PR TITLE
fix: 테이블 첫 번째 행에만 배경색을 적용했는데 이외 모든 행에 배경색이 적용되는 현상 수정 (#28)

### DIFF
--- a/hwpxtemplater-core/src/main/java/io/github/mumberrymountain/model/table/Cell.java
+++ b/hwpxtemplater-core/src/main/java/io/github/mumberrymountain/model/table/Cell.java
@@ -4,7 +4,7 @@ import io.github.mumberrymountain.model.Text;
 
 public class Cell {
     private final Text text;
-    private String backgroundColor = "None";
+    private String backgroundColor = "#FFFFFF";
     private boolean border = true;
     private String borderColor = "#000000";
     private Align align;

--- a/hwpxtemplater-core/src/main/java/io/github/mumberrymountain/render/RendererUtil.java
+++ b/hwpxtemplater-core/src/main/java/io/github/mumberrymountain/render/RendererUtil.java
@@ -1,5 +1,6 @@
 package io.github.mumberrymountain.render;
 
+import io.github.mumberrymountain.model.table.Cell;
 import kr.dogfoot.hwpxlib.object.content.section_xml.SectionXMLFile;
 import io.github.mumberrymountain.Config;
 import io.github.mumberrymountain.ConfigOption;
@@ -57,6 +58,13 @@ public class RendererUtil {
         return String.join(";",
                 String.valueOf(align)
                );
+    }
+
+    public static String createBorderStyleKey(Cell cell) {
+        return String.join(";",
+                String.valueOf(cell.getBorderColor()),
+                String.valueOf(cell.getBackgroundColor())
+        );
     }
 
     public static boolean isFullWidthPlaceHolder(char c) {

--- a/hwpxtemplater-core/src/main/java/io/github/mumberrymountain/render/RendererUtil.java
+++ b/hwpxtemplater-core/src/main/java/io/github/mumberrymountain/render/RendererUtil.java
@@ -63,7 +63,8 @@ public class RendererUtil {
     public static String createBorderStyleKey(Cell cell) {
         return String.join(";",
                 String.valueOf(cell.getBorderColor()),
-                String.valueOf(cell.getBackgroundColor())
+                String.valueOf(cell.getBackgroundColor()),
+                String.valueOf(cell.isBorder())
         );
     }
 

--- a/hwpxtemplater-core/src/main/java/io/github/mumberrymountain/render/placeholder/PlaceHolder.java
+++ b/hwpxtemplater-core/src/main/java/io/github/mumberrymountain/render/placeholder/PlaceHolder.java
@@ -14,7 +14,6 @@ public class PlaceHolder {
     private final String data;
 
     private final DelimPos delimPos;
-    private char typeChar;
 
     public PlaceHolder(T t, String delimStart, String delimEnd) {
         this(null, t, delimStart, delimEnd);
@@ -31,7 +30,6 @@ public class PlaceHolder {
     }
 
     private void checkType(char typeChar){
-        this.typeChar = typeChar;
         if (RendererUtil.isFullWidthPlaceHolder(typeChar)) typeChar = RendererUtil.normalizeFullWidthPlaceHolder(typeChar);
         for (PlaceHolderType placeholderType : PlaceHolderType.values()) {
             Character mappedChar = PlaceHolderCharRole.get(placeholderType);

--- a/hwpxtemplater-core/src/main/java/io/github/mumberrymountain/render/style/BorderRenderer.java
+++ b/hwpxtemplater-core/src/main/java/io/github/mumberrymountain/render/style/BorderRenderer.java
@@ -82,7 +82,7 @@ public class BorderRenderer {
         fillBrush.winBrush().alpha((float) 0);
     }
 
-    public String render(){
+    public BorderFill render(){
         setId();
 
         if (cell.isBorder()) {
@@ -96,7 +96,6 @@ public class BorderRenderer {
         setFillBrush(cell.getBackgroundColor(), "#000000");
 
         headerXMLFile.refList().borderFills().add(borderFill);
-
-        return borderFill.id();
+        return borderFill;
     }
 }

--- a/hwpxtemplater-core/src/main/java/io/github/mumberrymountain/render/style/StyleRenderer.java
+++ b/hwpxtemplater-core/src/main/java/io/github/mumberrymountain/render/style/StyleRenderer.java
@@ -1,6 +1,7 @@
 package io.github.mumberrymountain.render.style;
 
 import kr.dogfoot.hwpxlib.object.content.header_xml.HeaderXMLFile;
+import kr.dogfoot.hwpxlib.object.content.header_xml.references.BorderFill;
 import kr.dogfoot.hwpxlib.object.content.header_xml.references.CharPr;
 import kr.dogfoot.hwpxlib.object.content.header_xml.references.ParaPr;
 import io.github.mumberrymountain.model.Text;
@@ -15,6 +16,7 @@ public class StyleRenderer {
     private final HeaderXMLFile headerXMLFile;
     private final Map<String, CharPr> charPrs = new HashMap<String, CharPr>();
     private final Map<String, ParaPr> paraPrs = new HashMap<String, ParaPr>();
+    private final Map<String, BorderFill> borderFillIds = new HashMap<String, BorderFill>();
 
     public StyleRenderer (HeaderXMLFile headerXMLFile){
         this.headerXMLFile = headerXMLFile;
@@ -35,7 +37,13 @@ public class StyleRenderer {
     }
 
     public String renderBorderStyle(Cell cell) {
-        return new BorderRenderer(headerXMLFile, cell).render();
+        String key = RendererUtil.createBorderStyleKey(cell);
+        if (borderFillIds.containsKey(key)) return borderFillIds.get(key).id();
+
+        BorderFill borderFill = new BorderRenderer(headerXMLFile, cell).render();
+        borderFillIds.put(key, borderFill);
+
+        return borderFill.id();
     }
 
     public String renderParaStyleAndReturnParaPrId(Align align) {


### PR DESCRIPTION
1. 테이블 첫 번째 행에만 배경색을 적용했는데 이외 모든 행에 배경색이 적용되는 현상 수정 
2. 플라이웨이트 패턴 이용해 동일한 BorderFill이 있는 경우 중복하여 생성시키지 않도록 리팩토링

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 테이블 셀의 기본 배경색이 흰색(#FFFFFF)으로 변경되었습니다.
  * 테두리 및 배경 스타일 렌더링이 캐시 및 중복 제거로 최적화되어 렌더링 성능이 향상되었습니다.

* **리팩터링**
  * 내부 렌더링 및 플레이스홀더 타입 처리 로직이 간소화되어 코드 유지보수성이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->